### PR TITLE
맛집 생성/수정/삭제 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,11 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	//jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/project/review/common/error/ErrorCode.java
+++ b/src/main/java/com/project/review/common/error/ErrorCode.java
@@ -16,9 +16,11 @@ public enum ErrorCode {
 
   //User
   USER_NOT_FOUND(404, "U1", "해당 유저가 존재하지 않습니다"),
-  DUPLICATED_USER(400, "U2", "이미 가입되어 있는 유저입니다");
+  DUPLICATED_USER(400, "U2", "이미 가입되어 있는 유저입니다"),
 
-
+  //Restaurant
+  RESTAURANT_NOT_FOUND(404, "R1", "해당 레스토랑이 존재하지 않습니다"),
+  INVALID_RESTAURANT_RELATION(400, "R2", "잘못된 요청입니다");
 
 
   private final int status;

--- a/src/main/java/com/project/review/common/model/BaseCreatedTime.java
+++ b/src/main/java/com/project/review/common/model/BaseCreatedTime.java
@@ -1,0 +1,19 @@
+package com.project.review.common.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseCreatedTime {
+
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/com/project/review/common/model/BaseTime.java
+++ b/src/main/java/com/project/review/common/model/BaseTime.java
@@ -1,0 +1,25 @@
+package com.project.review.common.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTime {
+
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column
+  private LocalDateTime modifiedAt;
+}
+

--- a/src/main/java/com/project/review/config/JpaConfig.java
+++ b/src/main/java/com/project/review/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.project.review.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+}

--- a/src/main/java/com/project/review/controller/MemberController.java
+++ b/src/main/java/com/project/review/controller/MemberController.java
@@ -1,0 +1,26 @@
+package com.project.review.controller;
+
+import com.project.review.dto.MemberResponseDto;
+import com.project.review.service.MemberService;
+import com.project.review.util.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+  private final MemberService memberService;
+
+  @GetMapping("/member/me")
+  public ResponseEntity<MemberResponseDto> findMemberInfoById() {
+    return ResponseEntity.ok(memberService.findMemberInfoById(SecurityUtil.getCurrentMemberId()));
+  }
+
+  @GetMapping("/member/{email}")
+  public ResponseEntity<MemberResponseDto> findMemberInfoByEmail(@PathVariable String email) {
+    return ResponseEntity.ok(memberService.findMemberInfoByEmail(email));
+  }
+}

--- a/src/main/java/com/project/review/controller/RestaurantController.java
+++ b/src/main/java/com/project/review/controller/RestaurantController.java
@@ -1,0 +1,80 @@
+package com.project.review.controller;
+
+import com.project.review.controller.request.ModifyRestaurantRequestDto;
+import com.project.review.controller.request.SaveRestaurantRequestDto;
+import com.project.review.model.Restaurant;
+import com.project.review.service.RestaurantService;
+import com.project.review.service.usecase.DeleteRestaurantCommand;
+import jakarta.validation.constraints.Min;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@RequiredArgsConstructor
+@RestController
+@Validated
+public class RestaurantController {
+
+  private final RestaurantService restaurantService;
+
+  @PostMapping("/restaurant")
+  public ResponseEntity<Object> createRestaurant(
+      @RequestBody SaveRestaurantRequestDto saveRestaurantRequestDto,
+      @AuthenticationPrincipal UserDetails userDetails
+  ){
+    long userId = Long.parseLong(userDetails.getUsername());
+
+    Restaurant restaurant = restaurantService.createRestaurant(
+        saveRestaurantRequestDto.toCommand(userId));
+
+    URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+        .path("/{id}")
+        .buildAndExpand(restaurant.getId())
+        .toUri();
+
+    return ResponseEntity.created(location).build();
+  }
+
+//  @GetMapping("/restaurants")
+//  public ResponseEntity<Object> getRestaurants(){
+//
+//  }
+//
+  @PutMapping("/restaurant/{restaurantId}")
+  public ResponseEntity<Object> getSingleRestaurant(
+      @PathVariable @Min(1) Long restaurantId,
+      @RequestBody ModifyRestaurantRequestDto modifyRestaurantRequestDto,
+      @AuthenticationPrincipal UserDetails userDetails
+  ){
+    long userId = Long.parseLong(userDetails.getUsername());
+
+    restaurantService.modifyRestaurant(
+        modifyRestaurantRequestDto.toCommand(userId,restaurantId));
+
+    return ResponseEntity.ok().build();
+  }
+
+  @DeleteMapping("/restaurant/{restaurantId}")
+  public ResponseEntity<Object> deleteRestaurant(
+      @PathVariable("restaurantId") @Min(1) Long restaurantId,
+      @AuthenticationPrincipal UserDetails userDetails
+  ){
+    long userId = Long.parseLong(userDetails.getUsername());
+
+    restaurantService.deleteRestaurant(new DeleteRestaurantCommand(userId,restaurantId));
+
+    return ResponseEntity.noContent().build();
+  }
+
+}

--- a/src/main/java/com/project/review/controller/request/ModifyRestaurantRequestDto.java
+++ b/src/main/java/com/project/review/controller/request/ModifyRestaurantRequestDto.java
@@ -1,0 +1,14 @@
+package com.project.review.controller.request;
+
+import com.project.review.service.usecase.ModifyRestaurantCommand;
+import java.util.List;
+
+public record ModifyRestaurantRequestDto(
+    String name,
+    String address,
+    List<SaveMenuRequestDto> menus
+) {
+  public ModifyRestaurantCommand toCommand(Long memberId, Long restaurantId){
+    return new ModifyRestaurantCommand(memberId,restaurantId,name,address,menus);
+  }
+}

--- a/src/main/java/com/project/review/controller/request/SaveMenuRequestDto.java
+++ b/src/main/java/com/project/review/controller/request/SaveMenuRequestDto.java
@@ -1,0 +1,8 @@
+package com.project.review.controller.request;
+
+public record SaveMenuRequestDto(
+    String menuName,
+    Integer price
+) {
+
+}

--- a/src/main/java/com/project/review/controller/request/SaveRestaurantRequestDto.java
+++ b/src/main/java/com/project/review/controller/request/SaveRestaurantRequestDto.java
@@ -1,0 +1,14 @@
+package com.project.review.controller.request;
+
+import com.project.review.service.usecase.SaveRestaurantCommand;
+import java.util.List;
+
+public record SaveRestaurantRequestDto(
+    String name,
+    String address,
+    List<SaveMenuRequestDto> menus
+) {
+  public SaveRestaurantCommand toCommand(Long userId){
+    return new SaveRestaurantCommand(name, address, menus, userId);
+  }
+}

--- a/src/main/java/com/project/review/model/Authority.java
+++ b/src/main/java/com/project/review/model/Authority.java
@@ -1,0 +1,5 @@
+package com.project.review.model;
+
+public enum Authority {
+  ROLE_USER, ROLE_ADMIN
+}

--- a/src/main/java/com/project/review/model/Member.java
+++ b/src/main/java/com/project/review/model/Member.java
@@ -1,0 +1,43 @@
+package com.project.review.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "member_id")
+  private Long id;
+
+  @Column(name = "email")
+  private String email;
+
+  @Column(name = "password")
+  private String password;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "authority")
+  private Authority authority;
+
+  @Builder
+  public Member(String email, String password, Authority authority) {
+    this.email = email;
+    this.password = password;
+    this.authority = authority;
+  }
+}

--- a/src/main/java/com/project/review/model/Menu.java
+++ b/src/main/java/com/project/review/model/Menu.java
@@ -1,0 +1,48 @@
+package com.project.review.model;
+
+import com.project.review.common.model.BaseTime;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+@Entity
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Menu extends BaseTime {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "menu_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "restaurant_id")    // 단방향 매핑
+  private Restaurant restaurant;
+
+  @Column(name = "menu_name")
+  private String name;
+
+  @Column(name = "menu_price")
+  private Integer price;
+
+  @Builder
+  public Menu(Restaurant restaurant, String name, Integer price) {
+    this.restaurant = restaurant;
+    this.name = name;
+    this.price = price;
+  }
+}

--- a/src/main/java/com/project/review/model/Restaurant.java
+++ b/src/main/java/com/project/review/model/Restaurant.java
@@ -1,0 +1,57 @@
+package com.project.review.model;
+
+import com.project.review.common.model.BaseTime;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+@Entity
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Restaurant extends BaseTime {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "restaurant_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id")    // 단방향 매핑
+  private Member member;
+
+  @Column(name = "restaurant_name")
+  private String name;
+
+  @Column(name = "restaurant_address")
+  private String address;
+
+  @Builder
+  public Restaurant(Member member, String name, String address) {
+    this.member = member;
+    this.name = name;
+    this.address = address;
+  }
+
+  public void modifyInfo(Restaurant modifiedEntity) {
+    if ((modifiedEntity.name != null)) {
+      this.name = modifiedEntity.name;
+    }
+    if (modifiedEntity.address != null) {
+      this.address = modifiedEntity.address;
+    }
+  }
+}

--- a/src/main/java/com/project/review/repository/MemberRepository.java
+++ b/src/main/java/com/project/review/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.project.review.repository;
+
+import com.project.review.model.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member,Long> {
+
+  boolean existsByEmail(String email);
+
+  Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/com/project/review/repository/MenuRepository.java
+++ b/src/main/java/com/project/review/repository/MenuRepository.java
@@ -1,0 +1,10 @@
+package com.project.review.repository;
+
+import com.project.review.model.Menu;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuRepository extends JpaRepository<Menu,Long> {
+
+   List<Menu> findAllByRestaurantId(Long restaurantId);
+}

--- a/src/main/java/com/project/review/repository/RestaurantRepository.java
+++ b/src/main/java/com/project/review/repository/RestaurantRepository.java
@@ -1,0 +1,8 @@
+package com.project.review.repository;
+
+import com.project.review.model.Restaurant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+
+}

--- a/src/main/java/com/project/review/service/AuthService.java
+++ b/src/main/java/com/project/review/service/AuthService.java
@@ -11,6 +11,7 @@ import com.project.review.repository.MemberRepository;
 import com.project.review.repository.RefreshTokenRepository;
 import com.project.review.service.exception.DuplicatedUserException;
 import com.project.review.service.exception.LogoutUserException;
+import com.project.review.service.exception.NotMatchTokenUserException;
 import com.project.review.service.exception.RefreshTokenNotValidException;
 import com.project.review.service.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -86,7 +87,7 @@ public class AuthService {
 
     // 4. Refresh Token 일치하는지 검사
     if(!refreshToken.getValue().equals(tokenRequestDto.refreshToken())){
-      throw new UserNotFoundException();
+      throw new NotMatchTokenUserException();
     }
 
     // 5. 새로운 토큰 생성

--- a/src/main/java/com/project/review/service/MemberService.java
+++ b/src/main/java/com/project/review/service/MemberService.java
@@ -1,0 +1,27 @@
+package com.project.review.service;
+
+import com.project.review.dto.MemberResponseDto;
+import com.project.review.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class MemberService {
+
+  private final MemberRepository memberRepository;
+
+  public MemberResponseDto findMemberInfoById(Long memberId) {
+    return memberRepository.findById(memberId)
+        .map(MemberResponseDto::of)
+        .orElseThrow(() -> new RuntimeException("로그인 유저 정보가 없습니다."));
+  }
+
+  public MemberResponseDto findMemberInfoByEmail(String email) {
+    return memberRepository.findByEmail(email)
+        .map(MemberResponseDto::of)
+        .orElseThrow(() -> new RuntimeException("유저 정보가 없습니다."));
+  }
+}

--- a/src/main/java/com/project/review/service/RestaurantService.java
+++ b/src/main/java/com/project/review/service/RestaurantService.java
@@ -1,0 +1,106 @@
+package com.project.review.service;
+
+import com.project.review.controller.request.SaveMenuRequestDto;
+import com.project.review.model.Member;
+import com.project.review.model.Menu;
+import com.project.review.model.Restaurant;
+import com.project.review.repository.MemberRepository;
+import com.project.review.repository.MenuRepository;
+import com.project.review.repository.RestaurantRepository;
+import com.project.review.service.exception.InvalidRestaurantException;
+import com.project.review.service.exception.RestaurantNotFoundException;
+import com.project.review.service.exception.UserNotFoundException;
+import com.project.review.service.usecase.DeleteRestaurantCommand;
+import com.project.review.service.usecase.ModifyRestaurantCommand;
+import com.project.review.service.usecase.SaveRestaurantCommand;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class RestaurantService {
+
+  private final MemberRepository memberRepository;
+  private final RestaurantRepository restaurantRepository;
+  private final MenuRepository menuRepository;
+
+  @Transactional
+  public Restaurant createRestaurant(SaveRestaurantCommand saveRestaurantCommand){
+    Member member = findMember(saveRestaurantCommand.memberId());
+
+    Restaurant restaurantToSave = saveRestaurant(saveRestaurantCommand.toEntity(member));
+
+    saveRestaurantCommand.menus().forEach((menu) ->{
+      Menu menuToSave = makeMenu(menu, restaurantToSave);
+
+      menuRepository.save(menuToSave);
+    });
+
+    return restaurantToSave;
+  }
+
+  @Transactional
+  public void modifyRestaurant(ModifyRestaurantCommand modifyRestaurantCommand){
+    //레스토랑 정보 수정
+    Restaurant restaurantToModify = findRestaurant(modifyRestaurantCommand.restaurantId());
+
+    if(!restaurantToModify.getMember().getId().equals(modifyRestaurantCommand.memberId())){
+      throw new InvalidRestaurantException();
+    }
+    restaurantToModify.modifyInfo(modifyRestaurantCommand.toModifiedEntity());
+    restaurantRepository.save(restaurantToModify);
+
+    // 레스토랑과 연관된 메뉴 수정
+    List<Menu> menus = menuRepository.findAllByRestaurantId(modifyRestaurantCommand.restaurantId());
+    menuRepository.deleteAll(menus);
+
+    modifyRestaurantCommand.menus().forEach((menu) -> {
+      Menu menuToModify = Menu.builder()
+          .restaurant(restaurantToModify)
+          .name(menu.menuName())
+          .price(menu.price())
+          .build();
+
+      menuRepository.save(menuToModify);
+    });
+  }
+
+  @Transactional
+  public void deleteRestaurant(DeleteRestaurantCommand deleteRestaurantCommand){
+    Restaurant restaurantToDelete = findRestaurant(deleteRestaurantCommand.restaurantId());
+
+    if(!restaurantToDelete.getMember().getId().equals(deleteRestaurantCommand.memberId())){
+      throw new InvalidRestaurantException();
+    }
+    // 외래 키 제약조건때문에 menu 먼저 삭제
+    List<Menu> menus = menuRepository.findAllByRestaurantId(deleteRestaurantCommand.restaurantId());
+    menuRepository.deleteAll(menus);
+
+    // 레스토랑 삭제
+    restaurantRepository.delete(restaurantToDelete);
+  }
+
+  private Restaurant findRestaurant(Long restaurantId) {
+    return restaurantRepository.findById(restaurantId)
+        .orElseThrow(RestaurantNotFoundException::new);
+  }
+
+  private static Menu makeMenu(SaveMenuRequestDto menu, Restaurant restaurantToSave) {
+    return Menu.builder()
+        .restaurant(restaurantToSave)
+        .name(menu.menuName())
+        .price(menu.price())
+        .build();
+  }
+
+  private Restaurant saveRestaurant(Restaurant restaurant) {
+    return restaurantRepository.save(restaurant);
+  }
+
+  private Member findMember(Long memberId) {
+    return memberRepository.findById(memberId)
+        .orElseThrow(() -> new UserNotFoundException(memberId));
+  }
+}

--- a/src/main/java/com/project/review/service/exception/DuplicatedUserException.java
+++ b/src/main/java/com/project/review/service/exception/DuplicatedUserException.java
@@ -1,0 +1,11 @@
+package com.project.review.service.exception;
+
+import com.project.review.common.error.ErrorCode;
+import com.project.review.common.error.exception.BusinessException;
+
+public class DuplicatedUserException extends BusinessException {
+
+  public DuplicatedUserException() {
+    super(ErrorCode.DUPLICATED_USER);
+  }
+}

--- a/src/main/java/com/project/review/service/exception/InvalidRestaurantException.java
+++ b/src/main/java/com/project/review/service/exception/InvalidRestaurantException.java
@@ -1,0 +1,13 @@
+package com.project.review.service.exception;
+
+import static com.project.review.common.error.ErrorCode.INVALID_RESTAURANT_RELATION;
+
+import com.project.review.common.error.ErrorCode;
+import com.project.review.common.error.exception.BusinessException;
+
+public class InvalidRestaurantException extends BusinessException {
+
+  public InvalidRestaurantException() {
+    super(INVALID_RESTAURANT_RELATION);
+  }
+}

--- a/src/main/java/com/project/review/service/exception/NotMatchTokenUserException.java
+++ b/src/main/java/com/project/review/service/exception/NotMatchTokenUserException.java
@@ -1,0 +1,13 @@
+package com.project.review.service.exception;
+
+import static com.project.review.common.error.ErrorCode.TOKEN_USER_NOT_MATCH;
+
+import com.project.review.common.error.ErrorCode;
+import com.project.review.common.error.exception.BusinessException;
+
+public class NotMatchTokenUserException extends BusinessException {
+
+  public NotMatchTokenUserException() {
+    super(TOKEN_USER_NOT_MATCH);
+  }
+}

--- a/src/main/java/com/project/review/service/exception/RestaurantNotFoundException.java
+++ b/src/main/java/com/project/review/service/exception/RestaurantNotFoundException.java
@@ -1,0 +1,13 @@
+package com.project.review.service.exception;
+
+import static com.project.review.common.error.ErrorCode.RESTAURANT_NOT_FOUND;
+
+import com.project.review.common.error.ErrorCode;
+import com.project.review.common.error.exception.BusinessException;
+
+public class RestaurantNotFoundException extends BusinessException {
+
+  public RestaurantNotFoundException() {
+    super(RESTAURANT_NOT_FOUND);
+  }
+}

--- a/src/main/java/com/project/review/service/exception/UserNotFoundException.java
+++ b/src/main/java/com/project/review/service/exception/UserNotFoundException.java
@@ -1,0 +1,14 @@
+package com.project.review.service.exception;
+
+import static com.project.review.common.error.ErrorCode.USER_NOT_FOUND;
+
+import com.project.review.common.error.ErrorCode;
+import com.project.review.common.error.exception.BusinessException;
+
+public class UserNotFoundException extends BusinessException {
+
+
+  public UserNotFoundException(Long memberId) {
+    super("Member ID=" + memberId, USER_NOT_FOUND);
+  }
+}

--- a/src/main/java/com/project/review/service/usecase/DeleteRestaurantCommand.java
+++ b/src/main/java/com/project/review/service/usecase/DeleteRestaurantCommand.java
@@ -1,0 +1,8 @@
+package com.project.review.service.usecase;
+
+public record DeleteRestaurantCommand(
+    Long memberId,
+    Long restaurantId
+) {
+
+}

--- a/src/main/java/com/project/review/service/usecase/ModifyRestaurantCommand.java
+++ b/src/main/java/com/project/review/service/usecase/ModifyRestaurantCommand.java
@@ -1,0 +1,21 @@
+package com.project.review.service.usecase;
+
+import com.project.review.controller.request.SaveMenuRequestDto;
+import com.project.review.model.Restaurant;
+import java.util.List;
+
+public record ModifyRestaurantCommand(
+    Long memberId,
+    Long restaurantId,
+    String name,
+    String address,
+    List<SaveMenuRequestDto> menus
+) {
+
+  public Restaurant toModifiedEntity(){
+    return Restaurant.builder()
+        .name(name)
+        .address(address)
+        .build();
+  }
+}

--- a/src/main/java/com/project/review/service/usecase/SaveRestaurantCommand.java
+++ b/src/main/java/com/project/review/service/usecase/SaveRestaurantCommand.java
@@ -1,0 +1,23 @@
+package com.project.review.service.usecase;
+
+import com.project.review.controller.request.SaveMenuRequestDto;
+import com.project.review.model.Member;
+import com.project.review.model.Restaurant;
+import java.util.List;
+
+public record SaveRestaurantCommand(
+    String name,
+    String address,
+    List<SaveMenuRequestDto> menus,
+    Long memberId
+) {
+  public Restaurant toEntity(Member member) {
+    return Restaurant.builder()
+        .member(member)
+        .name(name)
+        .address(address)
+        .build();
+
+  }
+
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,7 +2,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
     show-sql: true
     open-in-view: false
     properties:
@@ -12,6 +12,5 @@ spring:
 logging:
   level:
     org.springframework.security: trace
-    com.zaxxer.hikari: TRACE
-    com.zaxxer.hikari.HikariConfig: DEBUG
-    org.hibernate.SQL: debug
+    com.zaxxer.hikari: debug
+


### PR DESCRIPTION
- 맛집 생성 API
1. 사용자 인증 후, 레스토랑의 이름&주소&메뉴의 이름,가격을 입력받아 생성한다

-맛집 수정 API
1. 수정하고 싶은 restaurant_id를 Controller에서 입력받아 Restaurant Entity를 가져온다
2.  PutMapping을 통해 수정 사항을 변경, 저장한다.

-맛집 삭제 API
1. 삭제하고 싶은 restaurant_id를 Controller에서 입력받아 Restaurant Entity를 가져온다
2. 외래키 제약조건으로 인해 Menu Entity를 먼저 삭제 후 그 다음에, Restaurant Entity를 삭제한다

 